### PR TITLE
catch JSON parse error instead of crashing

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,12 +78,16 @@ HTTPLock.prototype = {
         callback(error)
       } else {
         this.log.debug('Device response: %s', responseBody)
-        var json = JSON.parse(responseBody)
-        this.service.getCharacteristic(Characteristic.LockCurrentState).updateValue(json.lockCurrentState)
-        this.log.debug('Updated lockCurrentState to: %s', json.lockCurrentState)
-        this.service.getCharacteristic(Characteristic.LockTargetState).updateValue(json.lockTargetState)
-        this.log.debug('Updated lockTargetState to: %s', json.lockTargetState)
-        callback()
+        try {
+          var json = JSON.parse(responseBody)
+          this.service.getCharacteristic(Characteristic.LockCurrentState).updateValue(json.lockCurrentState)
+          this.log.debug('Updated lockCurrentState to: %s', json.lockCurrentState)
+          this.service.getCharacteristic(Characteristic.LockTargetState).updateValue(json.lockTargetState)
+          this.log.debug('Updated lockTargetState to: %s', json.lockTargetState)
+          callback()
+        } catch(e) {
+          this.log.warn('Error parsing status: %s', e.message)
+        }
       }
     }.bind(this))
   },


### PR DESCRIPTION
If the plugin v1.1.4 gets an improperly formed response from the lock, then it crashes Homebridge. Surrounding the `JSON.parse` with a **try/catch** will at least keep Homebridge alive and give the plugin a chance to report the error.