### PR TITLE
remove retryStatus

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,6 @@ HTTPLock.prototype = {
       if (error) {
         this.log.warn('Error getting status: %s', error.message)
         this.service.getCharacteristic(Characteristic.LockCurrentState).updateValue(new Error('Error getting status'))
-        this.retryStatus()
         callback(error)
       } else {
         this.log.debug('Device response: %s', responseBody)


### PR DESCRIPTION
`_getStatus` was calling a non-existent function `this.retryStatus()` when it experienced an error. This causes a Homebridge crash.